### PR TITLE
.github/workflows/sync-pot.yml: new workflow

### DIFF
--- a/.github/workflows/sync-pot.yml
+++ b/.github/workflows/sync-pot.yml
@@ -1,0 +1,39 @@
+name: sync-pot
+on:
+  schedule:
+    # Once a week, on Tuesday evening
+    - cron: '0 18 * * 2'
+  workflow_dispatch:
+jobs:
+  po-refresh:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+    steps:
+      - name: Set up
+        run: |
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+
+          sudo apt update
+          sudo apt install -y --no-install-recommends gettext
+
+      - name: Clone weblate repository
+        uses: actions/checkout@v2
+        with:
+          path: weblate
+
+      - name: Clone source repository
+        uses: actions/checkout@v2
+        with:
+          path: src
+          repository: cockpit-project/cockpit
+          ref: clean-pot
+
+      - name: Update .pot
+        run: |
+          make -C src -f pkg/build package-lock.json
+          make -C src -f po/Makefile.am po/cockpit.pot
+          cp src/po/cockpit.pot weblate/cockpit.pot
+          git -C weblate commit -m "Update source file" -- cockpit.pot
+          git -C weblate push


### PR DESCRIPTION
Drive the process of synchronising the .pot file from cockpit/
repository into cockpit-weblate repository from the -weblate repository
itself.

This means that we don't need any special credentials: the github.token
of the workflow is enough to write to the -weblate repository.

 - [x] cockpit-project/cockpit#16087
 - [ ] cockpit-project/cockpit#16088 (land simultaneously)

Test run (with only the branch name changed, since the changes aren't on cockpit `main` yet): 

 - https://github.com/allisoninc/cockpit-weblate/blob/main/.github/workflows/sync-pot.yml
 - https://github.com/allisoninc/cockpit-weblate/runs/3048500342?check_suite_focus=true
